### PR TITLE
Add latest tracking version

### DIFF
--- a/image_versions.json
+++ b/image_versions.json
@@ -1,6 +1,6 @@
 {
-    "scaleway-golang-1.9": {
-        "directory": "1.9",
+    "scaleway-golang-latest": {
+        "directory": "latest",
         "architectures": [
             "arm", "arm64", "x86_64"
         ],

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,0 +1,21 @@
+## -*- docker-image-name: "scaleway/golang:latest" -*-
+ARG ARCH
+FROM scaleway/ubuntu:${ARCH}-xenial
+
+
+MAINTAINER Scaleway <opensource@scaleway.com> (@scaleway)
+
+
+# Prepare rootfs for image-builder
+RUN /usr/local/sbin/builder-enter
+
+ARG GOVER
+
+# Install golang from PPA
+RUN add-apt-repository ppa:gophers/archive \
+    && apt-get -qq update \
+    && apt-get -qq install git golang-${GOVER}-go \
+    && echo "PATH=$PATH:/usr/lib/go-${GOVER}/bin/" > /etc/profile.d/golang.sh
+
+# Clean rootfs from image-builder
+RUN /usr/local/sbin/builder-leave

--- a/latest/env.mk
+++ b/latest/env.mk
@@ -1,0 +1,10 @@
+IMAGE_NAME = golang
+GOVER = $(shell curl --fail -s https://golang.org/VERSION?m=text | sed 's/go//' | cut -d'.' -f1-2)
+BUILD_ARGS = GOVER=$(GOVER)
+IMAGE_VERSION = stable-$(GOVER)
+IMAGE_VERSION_ALIASES = $(GOVER) latest
+IMAGE_TITLE = Golang $(GOVER)
+IMAGE_DESCRIPTION = The Go Programming Language
+IMAGE_SOURCE_URL = https://github.com/scaleway-community/scaleway-golang
+IMAGE_VENDOR_URL = https://golang.org/
+IMAGE_BOOTSCRIPT = mainline 4.4

--- a/latest/tim_tests/pytest/test_golang_version.py
+++ b/latest/tim_tests/pytest/test_golang_version.py
@@ -1,0 +1,10 @@
+'''
+Copyright (C) 2017 Scaleway. All rights reserved.
+Use of this source code is governed by a MIT-style
+license that can be found in the LICENSE file.
+'''
+
+
+def test_golang_version(host):
+    res = host.run('/usr/lib/go-1.9/bin/go version')
+    assert res.stdout.startswith('go version go1.9 linux')

--- a/latest/tim_tests/scaleway-golang.test.yml
+++ b/latest/tim_tests/scaleway-golang.test.yml
@@ -1,0 +1,4 @@
+file:
+  - path: /usr/lib/go-1.9/bin/go
+    owner: root:root
+    perm: 0775


### PR DESCRIPTION
These changes pull the latest go major release number to ensure each build stays at the true latest.